### PR TITLE
fix: use globalThis instead of self to address non Browser consumption

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,8 +39,10 @@ const config = {
   output: {
     filename: 'xterm.js',
     path: path.resolve('./lib'),
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    // Force usage of globalThis instead of global / self. (This is cross-env compatible)
+    globalObject: 'globalThis',
   },
-  mode: 'production'
+  mode: 'production',
 };
 module.exports = config;


### PR DESCRIPTION
Currently using this package in a non Browser env will cause an error as Webpack will emit `self` which does not exist in all envs such as Node.js and Workers.

This commit updates Webpack and force it to use `globalThis`. See: https://developer.mozilla.org/en-
US/docs/Web/JavaScript/Reference/Global_Objects/globalThis

<img width="1069" alt="Screenshot 2023-10-30 at 10 44 02" src="https://github.com/alan-agius4/xterm.js/assets/17563226/bb308516-0b58-4805-853b-530c8a418e7b">